### PR TITLE
Add browser configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,5 +33,8 @@ RUN tar --strip 1 -xvJf "${TOR_BINARY##*/}" && \
     chown -R ${USER_ID}:${GROUP_ID} /app && \
     rm "${TOR_BINARY##*/}" "${TOR_SIGNATURE##*/}"
 
+# Copy browser cfg
+COPY browser-cfg /browser-cfg
+
 # Add start script
 COPY startapp.sh /startapp.sh

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ See the docker-compose [here](https://github.com/DomiStyle/docker-tor-browser/bl
 
 The web interface will be available on port 5800.
 
-## Configuration
+## Platform configuration
 
 No special configuration is necessary, however some recommended variables are available:
 
@@ -26,9 +26,19 @@ No special configuration is necessary, however some recommended variables are av
 | `DISPLAY_WIDTH` | Set the width of the virtual screen | ``1280`` | No |
 | `DISPLAY_HEIGHT` | Set the height of the virtual screen | ``768`` | No |
 | `KEEP_APP_RUNNING` | Automatically restarts the Tor browser if it exits | ``0`` | No |
-| `TZ` | `Set the time zone for the container | - | No |
+| `TZ` | Set the time zone for the container | - | No |
 
-**For advanced configuration options please take a look [here](https://github.com/jlesage/docker-baseimage-gui#environment-variables).**
+** For advanced configuration options please take a look [here](https://github.com/jlesage/docker-baseimage-gui#environment-variables).**
+
+## Browser configuration
+
+You may install the browser with your own configuration. Copy the template configuration to get started.
+If `mozilla.cfg` is available then it is used, otherwise no browser changes are made.
+```
+cd browser-cfg
+cp mozilla.cfg.template mozilla.cfg
+```
+** For more information on the available options: http://kb.mozillazine.org/About:config_entries
 
 ## Volumes
 

--- a/browser-cfg/.gitignore
+++ b/browser-cfg/.gitignore
@@ -1,0 +1,1 @@
+mozilla.cfg

--- a/browser-cfg/autoconfig.js
+++ b/browser-cfg/autoconfig.js
@@ -1,0 +1,3 @@
+// Any comment. You must start the file with a single-line comment!
+pref("general.config.filename", "mozilla.cfg");
+pref("general.config.obscure_value", 0);

--- a/browser-cfg/mozilla.cfg.template
+++ b/browser-cfg/mozilla.cfg.template
@@ -1,0 +1,3 @@
+// Any comment. You must start the file with a comment!
+
+lockPref("javascript.enabled", false);

--- a/startapp.sh
+++ b/startapp.sh
@@ -1,5 +1,15 @@
 #!/bin/sh
 
+echo "Configuring Tor browser"
+
+cd /browser-cfg
+if [ -f "mozilla.cfg" ]
+then
+	echo "Copying browser config"
+	cp autoconfig.js /app/Browser/defaults/pref/autoconfig.js
+	cp mozilla.cfg /app/Browser/mozilla.cfg
+fi
+
 echo "Starting Tor browser"
 
 cd /app


### PR DESCRIPTION
Every time I start tor, I have to `about:config` and switch off javascript and stop it wasting my bandwidth downloading new versions of Tor when they are released and before you have updated the `Dockerfile`.

The folder `/browser-cfg` contains the relevant browser configuration files. If you don't want to change the browser then you can do nothing and it will behave as it did before. If you copy the template into place then it will be picked up and used.

I've added a `.gitignore` to the `browser-cfg` folder so that I can do future pulls without blowing away all my browser config settings.
