### PR TITLE
Fix version check workflow

### DIFF
--- a/.github/workflows/check-for-update.yml
+++ b/.github/workflows/check-for-update.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Update to latest version
         run: |
           current=$(awk -F '=' '/TOR_VERSION/{print $NF; exit}' Dockerfile | tr -d '"')
-          latest=$(curl -sSL https://api.github.com/repos/TheTorProject/gettorbrowser/releases/latest | \
+          curl -sSL https://api.github.com/repos/TheTorProject/gettorbrowser/releases/latest | \
           python3 -c "import sys, json; tag_name = json.load(sys.stdin)['tag_name']; print(tag_name[tag_name.index('-')+1:])" | \
           { read latest; dpkg --compare-versions $latest gt $current; }
           if [ $? == 0 ]; then

--- a/.github/workflows/check-for-update.yml
+++ b/.github/workflows/check-for-update.yml
@@ -13,8 +13,8 @@ jobs:
 
       - name: Update to latest version
         run: |
-          curl -sSL https://api.github.com/repos/TheTorProject/gettorbrowser/releases/latest | \
-          python3 -c "import sys, json; tag_name = json.load(sys.stdin)['tag_name']; print(tag_name[tag_name.index('-')+1:])"
+          latest=$(curl -sSL https://api.github.com/repos/TheTorProject/gettorbrowser/releases/latest | \
+          python3 -c "import sys, json; tag_name = json.load(sys.stdin)['tag_name']; print(tag_name[tag_name.index('-')+1:])")
           current=$(awk -F '=' '/TOR_VERSION/{print $NF; exit}' Dockerfile | tr -d '"')
           dpkg --compare-versions $latest gt $current
           if [ $? == 0 ]; then

--- a/.github/workflows/check-for-update.yml
+++ b/.github/workflows/check-for-update.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Update to latest version
         run: |
-          current="$(awk -F '=' '/TOR_VERSION/{print $NF; exit}' Dockerfile | tr -d '"')"
+          export current=$(awk -F '=' '/TOR_VERSION/{print $NF; exit}' Dockerfile | tr -d '"')
           curl -sSL https://api.github.com/repos/TheTorProject/gettorbrowser/releases/latest | \
           python3 -c "import sys, json; tag_name = json.load(sys.stdin)['tag_name']; print(tag_name[tag_name.index('-')+1:])" | \
           { read latest; dpkg --compare-versions $latest gt $current; }

--- a/.github/workflows/check-for-update.yml
+++ b/.github/workflows/check-for-update.yml
@@ -13,10 +13,10 @@ jobs:
 
       - name: Update to latest version
         run: |
-          latest=$(curl -sSL https://api.github.com/repos/TheTorProject/gettorbrowser/releases/latest | \
-          python3 -c "import sys, json; tag_name = json.load(sys.stdin)['tag_name']; print(tag_name[tag_name.index('-')+1:])")
           current=$(awk -F '=' '/TOR_VERSION/{print $NF; exit}' Dockerfile | tr -d '"')
-          dpkg --compare-versions $latest gt $current
+          latest=$(curl -sSL https://api.github.com/repos/TheTorProject/gettorbrowser/releases/latest | \
+          python3 -c "import sys, json; tag_name = json.load(sys.stdin)['tag_name']; print(tag_name[tag_name.index('-')+1:])" | \
+          { read latest; dpkg --compare-versions $latest gt $current; }
           if [ $? == 0 ]; then
             sed -i s/TOR_VERSION=".*"/TOR_VERSION=\"$latest\"/g Dockerfile
             echo "TB_UPDATED=0" >> $GITHUB_ENV

--- a/.github/workflows/check-for-update.yml
+++ b/.github/workflows/check-for-update.yml
@@ -13,6 +13,7 @@ jobs:
 
       - name: Update to latest version
         run: |
+          sudo apt-get install libcurl4-openssl-dev
           release=$(curl -v -s 'https://api.github.com/repos/TheTorProject/gettorbrowser/releases/latest')
           latest=$(echo $release | python3 -c "import sys, json; tag_name = json.load(sys.stdin)['tag_name']; print(tag_name[tag_name.index('-')+1:])")
           current=$(awk -F '=' '/TOR_VERSION/{print $NF; exit}' Dockerfile | tr -d '"')

--- a/.github/workflows/check-for-update.yml
+++ b/.github/workflows/check-for-update.yml
@@ -4,10 +4,6 @@ on:
   schedule:
     - cron:  '0 0 * * *'  # daily at midnight
   workflow_dispatch:
-  
-defaults:
-  run:
-    shell: bash
 
 jobs:
   check-for-updates:
@@ -17,11 +13,13 @@ jobs:
 
       - name: Update to latest version
         run: |
+          latest=$( \
+            curl -sSL https://api.github.com/repos/TheTorProject/gettorbrowser/releases/latest | \
+            python3 -c "import sys, json; tag_name = json.load(sys.stdin)['tag_name']; print(tag_name[tag_name.index('-')+1:])" \
+          )
           current=$(awk -F '=' '/TOR_VERSION/{print $NF; exit}' Dockerfile | tr -d '"')
-          curl -sSL https://api.github.com/repos/TheTorProject/gettorbrowser/releases/latest | \
-          python3 -c "import sys, json; tag_name = json.load(sys.stdin)['tag_name']; print(tag_name[tag_name.index('-')+1:])" | \
-          { read latest; dpkg --compare-versions $latest gt $current; }
-          if [ $? == 0 ]; then
+          dpkg --compare-versions $latest gt $current && update=0 || update=1
+          if [ $update == 0 ]; then
             sed -i s/TOR_VERSION=".*"/TOR_VERSION=\"$latest\"/g Dockerfile
             echo "TB_UPDATED=0" >> $GITHUB_ENV
             echo "TB_VERSION=$latest" >> $GITHUB_ENV

--- a/.github/workflows/check-for-update.yml
+++ b/.github/workflows/check-for-update.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron:  '0 0 * * *'  # daily at midnight
   workflow_dispatch:
+  
+defaults:
+  run:
+    shell: bash
 
 jobs:
   check-for-updates:
@@ -13,7 +17,7 @@ jobs:
 
       - name: Update to latest version
         run: |
-          export current=$(awk -F '=' '/TOR_VERSION/{print $NF; exit}' Dockerfile | tr -d '"')
+          current=$(awk -F '=' '/TOR_VERSION/{print $NF; exit}' Dockerfile | tr -d '"')
           curl -sSL https://api.github.com/repos/TheTorProject/gettorbrowser/releases/latest | \
           python3 -c "import sys, json; tag_name = json.load(sys.stdin)['tag_name']; print(tag_name[tag_name.index('-')+1:])" | \
           { read latest; dpkg --compare-versions $latest gt $current; }

--- a/.github/workflows/check-for-update.yml
+++ b/.github/workflows/check-for-update.yml
@@ -13,8 +13,7 @@ jobs:
 
       - name: Update to latest version
         run: |
-          sudo apt-get install libcurl4-openssl-dev
-          release=$(curl -v -s 'https://api.github.com/repos/TheTorProject/gettorbrowser/releases/latest')
+          release=$(curl -v -sSL 'https://api.github.com/repos/TheTorProject/gettorbrowser/releases/latest')
           latest=$(echo $release | python3 -c "import sys, json; tag_name = json.load(sys.stdin)['tag_name']; print(tag_name[tag_name.index('-')+1:])")
           current=$(awk -F '=' '/TOR_VERSION/{print $NF; exit}' Dockerfile | tr -d '"')
           dpkg --compare-versions $latest gt $current

--- a/.github/workflows/check-for-update.yml
+++ b/.github/workflows/check-for-update.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Update to latest version
         run: |
-          release=$(curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/TheTorProject/gettorbrowser/releases/latest)
+          release=$(curl -sSLv https://api.github.com/repos/TheTorProject/gettorbrowser/releases/latest) && eval $release || exit 1
           latest=$(echo $release | python3 -c "import sys, json; tag_name = json.load(sys.stdin)['tag_name']; print(tag_name[tag_name.index('-')+1:])")
           current=$(awk -F '=' '/TOR_VERSION/{print $NF; exit}' Dockerfile | tr -d '"')
           dpkg --compare-versions $latest gt $current

--- a/.github/workflows/check-for-update.yml
+++ b/.github/workflows/check-for-update.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Update to latest version
         run: |
-          curl -sSL https://api.github.com/repos/TheTorProject/gettorbrowser/releases/latest
+          curl -sSL https://api.github.com/repos/TheTorProject/gettorbrowser/releases/latest | \
           python3 -c "import sys, json; tag_name = json.load(sys.stdin)['tag_name']; print(tag_name[tag_name.index('-')+1:])"
           current=$(awk -F '=' '/TOR_VERSION/{print $NF; exit}' Dockerfile | tr -d '"')
           dpkg --compare-versions $latest gt $current

--- a/.github/workflows/check-for-update.yml
+++ b/.github/workflows/check-for-update.yml
@@ -13,8 +13,8 @@ jobs:
 
       - name: Update to latest version
         run: |
-          release=$(curl -sSLv https://api.github.com/repos/TheTorProject/gettorbrowser/releases/latest) && eval $release || exit 1
-          latest=$(echo $release | python3 -c "import sys, json; tag_name = json.load(sys.stdin)['tag_name']; print(tag_name[tag_name.index('-')+1:])")
+          latest=$(curl -sSLv https://api.github.com/repos/TheTorProject/gettorbrowser/releases/latest) | \
+          python3 -c "import sys, json; tag_name = json.load(sys.stdin)['tag_name']; print(tag_name[tag_name.index('-')+1:])"
           current=$(awk -F '=' '/TOR_VERSION/{print $NF; exit}' Dockerfile | tr -d '"')
           dpkg --compare-versions $latest gt $current
           if [ $? == 0 ]; then

--- a/.github/workflows/check-for-update.yml
+++ b/.github/workflows/check-for-update.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Update to latest version
         run: |
-          current=$(awk -F '=' '/TOR_VERSION/{print $NF; exit}' Dockerfile | tr -d '"')
+          current="$(awk -F '=' '/TOR_VERSION/{print $NF; exit}' Dockerfile | tr -d '"')"
           curl -sSL https://api.github.com/repos/TheTorProject/gettorbrowser/releases/latest | \
           python3 -c "import sys, json; tag_name = json.load(sys.stdin)['tag_name']; print(tag_name[tag_name.index('-')+1:])" | \
           { read latest; dpkg --compare-versions $latest gt $current; }

--- a/.github/workflows/check-for-update.yml
+++ b/.github/workflows/check-for-update.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Update to latest version
         run: |
-          curl -sSLv https://api.github.com/repos/TheTorProject/gettorbrowser/releases/latest
+          curl -sSL https://api.github.com/repos/TheTorProject/gettorbrowser/releases/latest
           python3 -c "import sys, json; tag_name = json.load(sys.stdin)['tag_name']; print(tag_name[tag_name.index('-')+1:])"
           current=$(awk -F '=' '/TOR_VERSION/{print $NF; exit}' Dockerfile | tr -d '"')
           dpkg --compare-versions $latest gt $current

--- a/.github/workflows/check-for-update.yml
+++ b/.github/workflows/check-for-update.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Update to latest version
         run: |
-          latest=$(curl -sSLv https://api.github.com/repos/TheTorProject/gettorbrowser/releases/latest) | \
+          curl -sSLv https://api.github.com/repos/TheTorProject/gettorbrowser/releases/latest
           python3 -c "import sys, json; tag_name = json.load(sys.stdin)['tag_name']; print(tag_name[tag_name.index('-')+1:])"
           current=$(awk -F '=' '/TOR_VERSION/{print $NF; exit}' Dockerfile | tr -d '"')
           dpkg --compare-versions $latest gt $current

--- a/.github/workflows/check-for-update.yml
+++ b/.github/workflows/check-for-update.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Update to latest version
         run: |
-          release=$(curl -s 'https://api.github.com/repos/TheTorProject/gettorbrowser/releases/latest')
+          release=$(curl -v -s 'https://api.github.com/repos/TheTorProject/gettorbrowser/releases/latest')
           latest=$(echo $release | python3 -c "import sys, json; tag_name = json.load(sys.stdin)['tag_name']; print(tag_name[tag_name.index('-')+1:])")
           current=$(awk -F '=' '/TOR_VERSION/{print $NF; exit}' Dockerfile | tr -d '"')
           dpkg --compare-versions $latest gt $current

--- a/.github/workflows/check-for-update.yml
+++ b/.github/workflows/check-for-update.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Update to latest version
         run: |
-          release=$(curl -v -sSL 'https://api.github.com/repos/TheTorProject/gettorbrowser/releases/latest')
+          release=$(curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/TheTorProject/gettorbrowser/releases/latest)
           latest=$(echo $release | python3 -c "import sys, json; tag_name = json.load(sys.stdin)['tag_name']; print(tag_name[tag_name.index('-')+1:])")
           current=$(awk -F '=' '/TOR_VERSION/{print $NF; exit}' Dockerfile | tr -d '"')
           dpkg --compare-versions $latest gt $current


### PR DESCRIPTION
This was difficult notice based on the workflow output. In GitHub Actions, the error output made it look like the variable assignment was causing the issue, but the workflow was actually executing all the way to the `dpkg` command and then failing because `dpkg` returns `1` when there is no update needed. To fix it from erroring when there is no updated needed, I had to modify that line to always return `0`.

Since I was basing the rest of the workflow steps on the return code of `dpkg`, I had to fix that too. Instead of checking the return code of the `dpkg` command, I had it create a bash variable to save whether or not it needed to update.