### PR TITLE
fixed x64 update and build

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -26,8 +26,8 @@ jobs:
         uses: rickstaa/action-create-tag@v1
         with:
           force_push_tag: true
-          tag: "arm-${{ env.VERSION_ARM64 }}"
-          message: "Tor Browser v${{ env.VERSION_ARM64 }}"
+          tag: "arm64-${{ env.VERSION_ARM64 }}"
+          message: "Tor Browser v${{ env.VERSION_ARM64 }} (arm64)"
 
       - name: Tag as latest
         uses: rickstaa/action-create-tag@v1

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -26,7 +26,7 @@ jobs:
         uses: rickstaa/action-create-tag@v1
         with:
           force_push_tag: true
-          tag: "${{ env.VERSION_ARM64 }}"
+          tag: "arm-${{ env.VERSION_ARM64 }}"
           message: "Tor Browser v${{ env.VERSION_ARM64 }}"
 
       - name: Tag as latest

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -12,14 +12,22 @@ jobs:
 
       - name: Set environment variables
         run: |
-          echo "VERSION=$(awk -F '=' '/TOR_VERSION/{print $NF; exit}' Dockerfile | tr -d '"')" >> $GITHUB_ENV
+          echo "VERSION_X64=$(awk -F '=' '/TOR_VERSION_X64/{print $NF; exit}' Dockerfile | tr -d '"')" >> $GITHUB_ENV
+          echo "VERSION_ARM64=$(awk -F '=' '/TOR_VERSION_ARM64/{print $NF; exit}' Dockerfile | tr -d '"')" >> $GITHUB_ENV
 
-      - name: Create version tag
+      - name: Create version tag for x64
         uses: rickstaa/action-create-tag@v1
         with:
           force_push_tag: true
-          tag: "${{ env.VERSION }}"
-          message: "Tor Browser v${{ env.VERSION }}"
+          tag: "${{ env.VERSION_X64 }}"
+          message: "Tor Browser v${{ env.VERSION_X64 }}"
+
+      - name: Create version tag for arm64
+        uses: rickstaa/action-create-tag@v1
+        with:
+          force_push_tag: true
+          tag: "${{ env.VERSION_ARM64 }}"
+          message: "Tor Browser v${{ env.VERSION_ARM64 }}"
 
       - name: Tag as latest
         uses: rickstaa/action-create-tag@v1
@@ -47,13 +55,24 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Build and push x64
         uses: docker/build-push-action@v3
         with:
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/tor-browser:${{ env.VERSION }}
             ${{ secrets.DOCKERHUB_USERNAME }}/tor-browser:latest
             ghcr.io/domistyle/docker-tor-browser:${{ env.VERSION }}
+            ghcr.io/domistyle/docker-tor-browser:latest
+
+      - name: Build and push arm64
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          platforms: linux/arm64
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/tor-browser:arm64-${{ env.VERSION }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/tor-browser:latest
+            ghcr.io/domistyle/docker-tor-browser:arm64-${{ env.VERSION }}
             ghcr.io/domistyle/docker-tor-browser:latest

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -61,9 +61,9 @@ jobs:
           push: true
           platforms: linux/amd64
           tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/tor-browser:${{ env.VERSION }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/tor-browser:${{ env.VERSION_X64 }}
             ${{ secrets.DOCKERHUB_USERNAME }}/tor-browser:latest
-            ghcr.io/domistyle/docker-tor-browser:${{ env.VERSION }}
+            ghcr.io/domistyle/docker-tor-browser:${{ env.VERSION_X64 }}
             ghcr.io/domistyle/docker-tor-browser:latest
 
       - name: Build and push arm64
@@ -72,7 +72,7 @@ jobs:
           push: true
           platforms: linux/arm64
           tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/tor-browser:arm64-${{ env.VERSION }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/tor-browser:arm64-${{ env.VERSION_ARM64 }}
             ${{ secrets.DOCKERHUB_USERNAME }}/tor-browser:latest
-            ghcr.io/domistyle/docker-tor-browser:arm64-${{ env.VERSION }}
+            ghcr.io/domistyle/docker-tor-browser:arm64-${{ env.VERSION_ARM64 }}
             ghcr.io/domistyle/docker-tor-browser:latest

--- a/.github/workflows/check-for-update-arm64.yml
+++ b/.github/workflows/check-for-update-arm64.yml
@@ -1,0 +1,33 @@
+name: Check for Tor Browser arm64 update
+
+on:
+  schedule:
+    - cron:  '0 1 * * *'  # daily at 01:00 UTC
+  workflow_dispatch:
+
+jobs:
+  check-for-updates:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Check if Tor Browser Ports has an arm64 build for the latest release
+        run: |
+          echo "TB_UPDATED=1" >> $GITHUB_ENV
+          latest=$(awk -F '=' '/TOR_VERSION_X64/{print $NF; exit}' Dockerfile | tr -d '"')
+          curl --fail -I -X GET https://sourceforge.net/projects/tor-browser-ports/files/$latest
+          current=$(awk -F '=' '/TOR_VERSION_ARM64/{print $NF; exit}' Dockerfile | tr -d '"')
+          dpkg --compare-versions $latest gt $current && update=0 || update=1
+          echo "TB_UPDATED=$update" >> $GITHUB_ENV
+          echo "TB_VERSION=$latest" >> $GITHUB_ENV
+        continue-on-error: true
+          
+      - name: Update arm64 to latest version and commit update
+        if: ${{ env.TB_UPDATED == 0 }}
+        run: |
+          sed -i s/TOR_VERSION_ARM64=".*"/TOR_VERSION_ARM64=\"${{ env.TB_VERSION }}\"/g Dockerfile
+          git config --global user.name "github-runner[bot]"
+          git config --global user.email "github-runner[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "Updated Tor Browser arm64 version to ${{ env.TB_VERSION }} " || echo
+          git push origin ${GITHUB_REF##*/} -f

--- a/.github/workflows/check-for-update-x64.yml
+++ b/.github/workflows/check-for-update-x64.yml
@@ -1,8 +1,8 @@
-name: Check for Tor Browser update
+name: Check for Tor Browser x64 update
 
 on:
   schedule:
-    - cron:  '0 0 * * *'  # daily at midnight
+    - cron:  '0 0 * * *'  # daily at 00:00 UTC
   workflow_dispatch:
 
 jobs:
@@ -11,16 +11,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Update to latest version
+      - name: Update x64 to latest version
         run: |
           latest=$( \
             curl -sSL https://api.github.com/repos/TheTorProject/gettorbrowser/releases/latest | \
             python3 -c "import sys, json; tag_name = json.load(sys.stdin)['tag_name']; print(tag_name[tag_name.index('-')+1:])" \
           )
-          current=$(awk -F '=' '/TOR_VERSION/{print $NF; exit}' Dockerfile | tr -d '"')
+          current=$(awk -F '=' '/TOR_VERSION_X64/{print $NF; exit}' Dockerfile | tr -d '"')
           dpkg --compare-versions $latest gt $current && update=0 || update=1
           if [ $update == 0 ]; then
-            sed -i s/TOR_VERSION=".*"/TOR_VERSION=\"$latest\"/g Dockerfile
+            sed -i s/TOR_VERSION_X64=".*"/TOR_VERSION_X64=\"$latest\"/g Dockerfile
             echo "TB_UPDATED=0" >> $GITHUB_ENV
             echo "TB_VERSION=$latest" >> $GITHUB_ENV
           else
@@ -33,6 +33,6 @@ jobs:
             git config --global user.name "github-runner[bot]"
             git config --global user.email "github-runner[bot]@users.noreply.github.com"
             git add .
-            git commit -m "Updated Tor Browser version to ${{ env.TB_VERSION }} " || echo
+            git commit -m "Updated Tor Browser x64 version to ${{ env.TB_VERSION }} " || echo
             git push origin ${GITHUB_REF##*/} -f
           fi


### PR DESCRIPTION
Builds arm64 and x64 images without error after commit bf646f09ba317913ac70338d3983d3e32ed2f138 added separate version variables for each architecture.

Also fixed version auto-update for x64. For now, arm64 versions will be manual (see below).

Version auto-update for arm64 will need to be a separate workflow since Tor Browser Ports lags slightly behind in version numbers. I'll create a separate PR with an auto-update workflow for arm64 that queries the Tor Browser Ports available versions.