### PR TITLE
fix latest tag being applied to arm64 image only

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -73,6 +73,6 @@ jobs:
           platforms: linux/arm64
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/tor-browser:arm64-${{ env.VERSION_ARM64 }}
-            ${{ secrets.DOCKERHUB_USERNAME }}/tor-browser:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/tor-browser:latest-arm64
             ghcr.io/domistyle/docker-tor-browser:arm64-${{ env.VERSION_ARM64 }}
-            ghcr.io/domistyle/docker-tor-browser:latest
+            ghcr.io/domistyle/docker-tor-browser:latest-arm64


### PR DESCRIPTION
I noticed the new build workflow was tagging the arm image as `latest` and not the x64 image. I modified the arm build to be tagged as `latest-arm64` to differentiate the two.