### PR TITLE
fixed build tags

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -59,20 +59,11 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
-          platforms: linux/amd64
+          platforms: linux/amd64, linux/arm64
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/tor-browser:${{ env.VERSION_X64 }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/tor-browser:arm64-${{ env.VERSION_ARM64 }}
             ${{ secrets.DOCKERHUB_USERNAME }}/tor-browser:latest
             ghcr.io/domistyle/docker-tor-browser:${{ env.VERSION_X64 }}
-            ghcr.io/domistyle/docker-tor-browser:latest
-
-      - name: Build and push arm64
-        uses: docker/build-push-action@v3
-        with:
-          push: true
-          platforms: linux/arm64
-          tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/tor-browser:arm64-${{ env.VERSION_ARM64 }}
-            ${{ secrets.DOCKERHUB_USERNAME }}/tor-browser:latest-arm64
             ghcr.io/domistyle/docker-tor-browser:arm64-${{ env.VERSION_ARM64 }}
-            ghcr.io/domistyle/docker-tor-browser:latest-arm64
+            ghcr.io/domistyle/docker-tor-browser:latest


### PR DESCRIPTION
Realized I didn't need to break out the different architectures into their own build steps... I just needed to add the arm tags to the old step. This simplifies things and allows arm64 to use the standard `latest` tag again.