### PR TITLE
fixed missing dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,6 +90,7 @@ RUN apt-get update \
     libgtk-3-0 \
     libx11-xcb1 \
     libxt6 \
+    libasound2 \
   && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app /app


### PR DESCRIPTION
Browser was silently crashing on startup after 12.0 update. Running `start-tor-browser` in verbose mode revealed that it was trying to load a missing module `libasound2`. I added it to the Dockerfile in the `apt install` step.